### PR TITLE
Rgba support hex

### DIFF
--- a/modules/functions/rgba.js
+++ b/modules/functions/rgba.js
@@ -1,6 +1,15 @@
 import isObject from '../utils/isObject'
+import { hexToRgb } from '../utils/color'
 
 export default function rgba(r, g, b, a) {
-  const values = isObject(r) ? [ r.red, r.green, r.blue, r.alpha ] : [ r, g, b, a ]
+  let values
+
+  if (isObject(r)) { // rgba({ red: 23, green: 63, blue: 99, alpha: 0.2 })
+    values = [ r.red, r.green, r.blue, r.alpha ]
+  } else if (typeof r === 'string') { // rgba('#173f63', 0.2)
+    values = [ ...hexToRgb(r), g ]
+  } else { // rgba(23, 63, 99, 0.2)
+    values = [ r, g, b, a ]
+  }
   return 'rgba(' + values.join(',') + ')'
 }

--- a/modules/utils/color.js
+++ b/modules/utils/color.js
@@ -1,0 +1,14 @@
+/*
+    hexToRgb("#0033ff") => [0, 51, 255]
+    hexToRgb("#03f") => [0, 51, 255]
+*/
+
+export function hexToRgb(hex = '#000000') {
+  return hex
+    .replace(
+      /^#?([a-f\d])([a-f\d])([a-f\d])$/i,
+      (m, r, g, b) => '#' + r + r + g + g + b + b
+    )
+    .substring(1).match(/.{2}/g)
+    .map(x => parseInt(x, 16))
+}

--- a/test/functions/rgba.js
+++ b/test/functions/rgba.js
@@ -1,0 +1,17 @@
+import { expect } from 'chai'
+import rgba from '../../modules/functions/rgba'
+
+describe('rgba', () => {
+  it('should return plain rgba value for regular use', () => {
+    expect(rgba(33, 44, 55, 0.3)).to.eql('rgba(33,44,55,0.3)')
+  })
+
+  it('should support object with red, green, blue and alpha values', () => {
+    expect(rgba({ red: 33, green: 44, blue: 55, alpha: 0.3 })).to.eql('rgba(33,44,55,0.3)')
+  })
+
+  it('should support hex color and an alpha', () => {
+    expect(rgba('#792763', 0.2)).to.eql('rgba(121,39,99,0.2)')
+    expect(rgba('#362', 0.5)).to.eql('rgba(51,102,34,0.5)')
+  })
+})

--- a/test/utils/color.js
+++ b/test/utils/color.js
@@ -1,0 +1,16 @@
+import { expect } from 'chai'
+import { hexToRgb } from '../../modules/utils/color'
+
+describe('Color utils', () => {
+  it('should convert hex to rgb', () => {
+    expect(hexToRgb('#0033ff')).to.eql([ 0, 51, 255 ])
+  })
+
+  it('should convert shorthand hex to rgb', () => {
+    expect(hexToRgb('#03f')).to.eql([ 0, 51, 255 ])
+  })
+
+  it('should default to black', () => {
+    expect(hexToRgb()).to.eql([ 0, 0, 0 ])
+  })
+})


### PR DESCRIPTION
Add hex color support for rgba() method so the following will work:
`expect(rgba('#792763', 0.2)).to.eql('rgba(121,39,99,0.2)')`