### PR TITLE
allow scale() to accept one arg like the spec

### DIFF
--- a/modules/functions/scale.js
+++ b/modules/functions/scale.js
@@ -2,5 +2,6 @@ import isObject from '../utils/isObject'
 
 export default function scale(x, y) {
   const values = isObject(x) ? [ x.x, x.y ] : [ x, y ]
+  if (typeof values[1] === 'undefined') values[1] = values[0]
   return 'scale(' + values.join(',') + ')'
 }


### PR DESCRIPTION
Makes scale behave like the spec when one arg is supplied. But the output still looks like `"scale(x, y)"`. Should we instead make it output like `"scale(x)"` in this case?